### PR TITLE
Adds flexible releases into Flipper

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,9 @@ Changed
 - Set up flipper to be more flexible towards releases
 - Flipper index page now accepts a base_url to control for production, testing environments and for changing releases
 - now uses uwsgi_param on nginx locations to determine flipper release, DR15, DR16, etc.
-- now assumes testing urls will be [release].sdss.utah.edu and production urls are [release].sdss.org
+- now also uses proxy set request header for nginx locations that are proxies
+- now assumes testing urls will be lore.sdss.utah.edu (or sas.sdss.org/test) and production urls are [release].sdss.org
+- flipper now looks for release from request header variable first, then FLIPPER_RELEASE environment variable
 
 0.1.1 (2018-11-30)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,11 +11,15 @@ Added
 - added test server for flipper with new uwsgi test.ini
 - added new FLIPPER_BASE envvar to allow for test server 
 - added flipper version to page footer 
+- added new FLIPPER_RELEASE environment variable which controls for DR versioning
 
 Changed
 ^^^^^^^
 - Updating links for DR16
-
+- Set up flipper to be more flexible towards releases
+- Flipper index page now accepts a base_url to control for production, testing environments and for changing releases
+- now uses uwsgi_param on nginx locations to determine flipper release, DR15, DR16, etc.
+- now assumes testing urls will be [release].sdss.utah.edu and production urls are [release].sdss.org
 
 0.1.1 (2018-11-30)
 ------------------

--- a/python/flipper/controllers/index.py
+++ b/python/flipper/controllers/index.py
@@ -47,7 +47,7 @@ def home():
     else:
         base_url = '{0}.sdss.org'.format(release)
         marvin_url = base_url
-    print(release, base_url, marvin_url)
+
     # build template parameter dictionary
     output = {'title': 'SDSS Splashpage', 'version': flipper.app.__version__,
               'release': release, 'istest': istestenv, 'base_url': base_url,

--- a/python/flipper/controllers/index.py
+++ b/python/flipper/controllers/index.py
@@ -9,10 +9,14 @@
 # @Last Modified time: 2018-08-16 11:58:34
 
 from __future__ import print_function, division, absolute_import
+import os
 import flipper.app
-from flask import Blueprint, render_template, jsonify
+from flask import Blueprint, render_template, jsonify, request
 
 index = Blueprint("index", __name__)
+
+# SDSS DR releases
+releases = ['dr15', 'dr16']
 
 
 @index.route('/status/', methods=['GET', 'POST'], endpoint='status')
@@ -23,5 +27,29 @@ def status():
 @index.route('/', methods=['GET'], endpoint='home')
 @index.route('/index/', methods=['GET'], endpoint='index')
 def home():
-    output = {'title': 'SDSS Splashpage', 'version': flipper.app.__version__}
+    # get release variable from Flask request
+    release = request.environ.get('FLIPPER_RELEASE', None)
+
+    # if no release try the os environment variable
+    if not release:
+        release = os.environ.get("FLIPPER_RELEASE", None)
+
+    # if no release, select the lastest one
+    if not release:
+        sorted_rels = sorted(releases, key=lambda x: int(x.split('dr')[-1]))
+        release = sorted_rels[-1]
+
+    # set base and marvin urls for production or testing
+    istestenv = 'test' in request.path
+    if istestenv:
+        base_url = '{0}.sdss.utah.edu'.format(release)
+        marvin_url = 'lore.sdss.utah.edu/test'
+    else:
+        base_url = '{0}.sdss.org'.format(release)
+        marvin_url = base_url
+    print(release, base_url, marvin_url)
+    # build template parameter dictionary
+    output = {'title': 'SDSS Splashpage', 'version': flipper.app.__version__,
+              'release': release, 'istest': istestenv, 'base_url': base_url,
+              'marvin_url': marvin_url}
     return render_template('index.html', **output)

--- a/python/flipper/controllers/index.py
+++ b/python/flipper/controllers/index.py
@@ -27,13 +27,13 @@ def status():
 @index.route('/', methods=['GET'], endpoint='home')
 @index.route('/index/', methods=['GET'], endpoint='index')
 def home():
-    # get release variable from Flask request
-    release = request.environ.get('FLIPPER_RELEASE', None)
-    print('request', request.environ)
-    print('request flipper release', release)
-    print('flipper test', os.environ.get("FLIPPER_TEST", None))
-    print('flipper url', request.url)
-    print('req headers', request.headers)
+    # get release from request header
+    release = request.headers.get('Release', None)
+
+    # if no release, get release variable from Flask request
+    if not release:
+        release = request.environ.get('FLIPPER_RELEASE', None)
+
     # if no release try the os environment variable
     if not release:
         release = os.environ.get("FLIPPER_RELEASE", None)
@@ -46,7 +46,7 @@ def home():
     # set base and marvin urls for production or testing
     istestenv = 'test' in request.path
     if istestenv:
-        base_url = '{0}.sdss.utah.edu'.format(release)
+        base_url = 'sas.sdss.org/test'
         marvin_url = 'lore.sdss.utah.edu/test'
     else:
         base_url = '{0}.sdss.org'.format(release)

--- a/python/flipper/controllers/index.py
+++ b/python/flipper/controllers/index.py
@@ -29,7 +29,11 @@ def status():
 def home():
     # get release variable from Flask request
     release = request.environ.get('FLIPPER_RELEASE', None)
-
+    print('request', request.environ)
+    print('request flipper release', release)
+    print('flipper test', os.environ.get("FLIPPER_TEST", None))
+    print('flipper url', request.url)
+    print('req headers', request.headers)
     # if no release try the os environment variable
     if not release:
         release = os.environ.get("FLIPPER_RELEASE", None)
@@ -42,7 +46,7 @@ def home():
     # set base and marvin urls for production or testing
     istestenv = 'test' in request.path
     if istestenv:
-        base_url = '{0}.sdss.org'.format(release)
+        base_url = '{0}.sdss.utah.edu'.format(release)
         marvin_url = 'lore.sdss.utah.edu/test'
     else:
         base_url = '{0}.sdss.org'.format(release)

--- a/python/flipper/controllers/index.py
+++ b/python/flipper/controllers/index.py
@@ -42,7 +42,7 @@ def home():
     # set base and marvin urls for production or testing
     istestenv = 'test' in request.path
     if istestenv:
-        base_url = '{0}.sdss.utah.edu'.format(release)
+        base_url = '{0}.sdss.org'.format(release)
         marvin_url = 'lore.sdss.utah.edu/test'
     else:
         base_url = '{0}.sdss.org'.format(release)

--- a/python/flipper/templates/index.html
+++ b/python/flipper/templates/index.html
@@ -125,7 +125,7 @@
                         </div>
                         </a>
 
-                        <a target="_blank" href="https://dr16.sdss.utah.edu/optical/">
+                        <a target="_blank" href="https://{{base_url}}/optical/">
                         <div class="card text-center" id='optical'>
                           <h5 class="card-header">Optical Spectra</h5>
                           <div class="card-body">
@@ -137,7 +137,7 @@
                         </div>
                         </a>
 
-                        <a target="_blank" href="https://dr16.sdss.utah.edu/infrared/">
+                        <a target="_blank" href="https://{{base_url}}/infrared/">
                         <div class="card text-center" id='infrared'>
                           <h5 class="card-header">Infrared Spectra</h5>
                           <div class="card-body">
@@ -152,7 +152,7 @@
                         <!-- this breaks after three cards -->
                         <div class='w-100'></div>
 
-                        <a target="_blank" href="https://lore.sdss.utah.edu/test/marvin/">
+                        <a target="_blank" href="https://{{marvin_url}}/marvin/">
                         <div class="card text-center" id='marvin'>
                           <h5 class="card-header">MaNGA Data with Marvin</h5>
                           <div class="card-body">
@@ -164,7 +164,7 @@
                         </div>
                         </a>
 
-                        <a target="_blank" href="https://dr16.sdss.utah.edu/mastar/">
+                        <a target="_blank" href="https://{{base_url}}/mastar/">
                         <div class="card text-center" id='mastar'>
                           <h5 class="card-header">MaNGA Stellar Library</h5>
                           <div class="card-body">

--- a/python/flipper/uwsgi/base.ini
+++ b/python/flipper/uwsgi/base.ini
@@ -1,9 +1,9 @@
 
 [uwsgi]
 
-#file = %(wwwdir)/%(module)/run_%(app_name)
+file = %(wwwdir)/%(module)/run_%(app_name)
 daemonize = %(wwwdir)/%(base)/log/%(app_name).log
-socket = %(socketdir)/uwsgi_%(app_name).sock
+socket = %(socketdir)/%(app_name).sock
 stats = %(socketdir)/%(base)_stats.sock
 
 master = true

--- a/python/flipper/uwsgi/base.ini
+++ b/python/flipper/uwsgi/base.ini
@@ -1,7 +1,7 @@
 
 [uwsgi]
 
-file = %(wwwdir)/%(module)/run_%(app_name)
+#file = %(wwwdir)/%(module)/run_%(app_name)
 daemonize = %(wwwdir)/%(base)/log/%(app_name).log
 socket = %(socketdir)/%(app_name).sock
 stats = %(socketdir)/%(base)_stats.sock

--- a/python/flipper/uwsgi/local.ini
+++ b/python/flipper/uwsgi/local.ini
@@ -14,4 +14,4 @@ base = flipper
 app_name = flipper
 env = FLASK_ENV=production
 
-ini = base.ini
+ini = %dbase.ini

--- a/python/flipper/uwsgi/production.ini
+++ b/python/flipper/uwsgi/production.ini
@@ -5,39 +5,11 @@
 [uwsgi]
 
 callable = app
-wwwdir = /home/var-www/dr15.sdss.org
-socketdir = /run/uwsgi/tmp/production
+wwwdir = /home/var-www/production    
+socketdir = /run/uwsgi/tmp/prodution
 module = flipper.uwsgi.app
 app_name = flipper
 env = FLASK_ENV=production
 
-file = %(wwwdir)/%(module)/run_%(app_name)
-daemonize = %(wwwdir)/%(module)/log/%(app_name).log
-socket = %(socketdir)/uwsgi_%(app_name).sock
-stats = %(socketdir)/%(module)_stats.sock
-
-master = true
-processes = 4
-
-chmod-socket = 666
-vacuum = true
-thunder-lock = true
-enable-threads = true
-lazy-apps = true
-
-sharedarea = 4
-limit-as = 8192
-reload-on-as = 4096
-reload-on-rss = 4096
-buffer-size = 65535
-
-memory-report = true
-
-# cheaper subsystem
-cheaper-algo = spare
-cheaper = 2
-cheaper-intial = 4
-workers = 10
-cheaper-step = 1
-cheaper-rss-limit-soft = 134217728
+ini = %dbase.ini
 

--- a/python/flipper/uwsgi/production.ini
+++ b/python/flipper/uwsgi/production.ini
@@ -5,10 +5,11 @@
 [uwsgi]
 
 callable = app
-wwwdir = /home/var-www/dr16.sdss.org
-socketdir = /run/uwsgi/tmp/dr16
-module = flipper
+wwwdir = /home/var-www/dr15.sdss.org
+socketdir = /run/uwsgi/tmp/production
+module = flipper.uwsgi.app
 app_name = flipper
+env = FLASK_ENV=production
 
 file = %(wwwdir)/%(module)/run_%(app_name)
 daemonize = %(wwwdir)/%(module)/log/%(app_name).log
@@ -25,9 +26,9 @@ enable-threads = true
 lazy-apps = true
 
 sharedarea = 4
-limit-as = 4096
-reload-on-as = 2048
-reload-on-rss = 2048
+limit-as = 8192
+reload-on-as = 4096
+reload-on-rss = 4096
 buffer-size = 65535
 
 memory-report = true

--- a/python/flipper/uwsgi/production.ini
+++ b/python/flipper/uwsgi/production.ini
@@ -9,6 +9,7 @@ wwwdir = /home/www/production
 socketdir = /run/uwsgi/tmp/production
 module = flipper.uwsgi.app
 app_name = flipper
+base = flipper
 env = FLASK_ENV=production
 
 ini = %dbase.ini

--- a/python/flipper/uwsgi/production.ini
+++ b/python/flipper/uwsgi/production.ini
@@ -5,8 +5,8 @@
 [uwsgi]
 
 callable = app
-wwwdir = /home/var-www/production    
-socketdir = /run/uwsgi/tmp/prodution
+wwwdir = /home/www/production    
+socketdir = /run/uwsgi/tmp/production
 module = flipper.uwsgi.app
 app_name = flipper
 env = FLASK_ENV=production

--- a/python/flipper/uwsgi/test.ini
+++ b/python/flipper/uwsgi/test.ini
@@ -9,36 +9,8 @@ wwwdir = /home/var-www/lore.sdss.utah.edu
 socketdir = /run/uwsgi/tmp/test
 tag = test
 module = flipper
+base = flipper
 app_name = flipper_%(tag)
 env = FLIPPER_BASE=test/flipper
 
-file = %(wwwdir)/%(module)/run_%(app_name)
-daemonize = %(wwwdir)/%(module)/log/%(app_name).log
-pidfile = %(wwwdir)/flipper/pid/%(app_name).pid
-socket = %(socketdir)/%(app_name).sock
-stats = %(socketdir)/%(module)_stats.sock
-
-master = true
-processes = 4
-
-chmod-socket = 666
-vacuum = true
-thunder-lock = true
-enable-threads = true
-lazy-apps = true
-
-sharedarea = 4
-limit-as = 4096
-reload-on-as = 2048
-reload-on-rss = 2048
-buffer-size = 65535
-
-memory-report = true
-
-# cheaper subsystem
-cheaper-algo = spare
-cheaper = 2
-cheaper-intial = 4
-workers = 10
-cheaper-step = 1
-cheaper-rss-limit-soft = 134217728
+ini = base.ini

--- a/python/flipper/uwsgi/test.ini
+++ b/python/flipper/uwsgi/test.ini
@@ -5,7 +5,7 @@
 [uwsgi]
 
 callable = app
-wwwdir = /home/var-www/lore.sdss.utah.edu
+wwwdir = /home/www/development
 socketdir = /run/uwsgi/tmp/test
 tag = test
 module = flipper.uwsgi.app

--- a/python/flipper/uwsgi/test.ini
+++ b/python/flipper/uwsgi/test.ini
@@ -8,9 +8,10 @@ callable = app
 wwwdir = /home/var-www/lore.sdss.utah.edu
 socketdir = /run/uwsgi/tmp/test
 tag = test
-module = flipper
+module = flipper.uwsgi.app
 base = flipper
 app_name = flipper_%(tag)
 env = FLIPPER_BASE=test/flipper
+env = FLASK_ENV=development
 
 ini = base.ini

--- a/python/flipper/uwsgi/test.ini
+++ b/python/flipper/uwsgi/test.ini
@@ -14,4 +14,4 @@ app_name = flipper_%(tag)
 env = FLIPPER_BASE=test/flipper
 env = FLASK_ENV=development
 
-ini = base.ini
+ini = %dbase.ini


### PR DESCRIPTION
This PR modifies flipper to accept more dynamic releases and updates the URLs used in the template.  It now looks for a `FLIPPER_RELEASE`  `os.environment` or `Flask.request.environ` variable and uses that to set the urls used in the html.  For production runs, it sets the url to `[release].sdss.org`.  For the test flipper web server, it sets the url to `[release].sdss.utah.edu`.    

The `FLIPPER_RELEASE` variable is now set in the flipper `nginx` locations for different DR configs, as `uwsgi_param FLIPPER_RELEASE dr15`.  This tells the flipper Flask app to use `dr15` as the release.   See https://github.com/sdss/config/commit/729e4b7e6f683de0600e721a1a90ae995147e812

With this setup, we can continue to use a single uwsgi `production.ini` file, but utilize different "versions" of the production site through the specific nginx `flipper.conf` files.  

